### PR TITLE
Norminetted cantalloc_handler()

### DIFF
--- a/cantalloc.c
+++ b/cantalloc.c
@@ -48,9 +48,7 @@ static void	*cantalloc_handler(size_t size, int mode)
 		return (new_ptr);
 	}
 	else if (mode == CLEAN)
-	{
 		clean_garbage_list(garbage_head);
-	}
 	return (NULL);
 }
 


### PR DESCRIPTION
Removed the brackets from the last 'else if' of cantalloc_handler() to reduce the code from 26 to 24 lines, in accordance with the 42 école norm.